### PR TITLE
Add Linux symlinks without removing macOS binaries

### DIFF
--- a/bin/linux/ffplay
+++ b/bin/linux/ffplay
@@ -1,0 +1,1 @@
+/usr/bin/ffplay

--- a/bin/linux/mkfifo
+++ b/bin/linux/mkfifo
@@ -1,0 +1,1 @@
+/usr/bin/mkfifo

--- a/bin/linux/pkill
+++ b/bin/linux/pkill
@@ -1,0 +1,1 @@
+/usr/bin/pkill

--- a/bun serv.ts
+++ b/bun serv.ts
@@ -15,7 +15,17 @@ const TTS_RATE = 190; // Speech rate for the 'say' command
 
 // --- Local bin path setup ---
 const ROOT = path.dirname(import.meta.path);
-const BIN = (f: string) => path.join(ROOT, "bin", f);
+const BIN = (f: string) => {
+  const platformDir = path.join(ROOT, "bin", process.platform);
+  const archDir = path.join(platformDir, process.arch);
+  const archPath = path.join(archDir, f);
+  if (fs.existsSync(archPath)) return archPath;
+
+  const platPath = path.join(platformDir, f);
+  if (fs.existsSync(platPath)) return platPath;
+
+  return path.join(ROOT, "bin", f);
+};
 
 const logInfo = (...args: any[]) => {};
 const logWarn = (...args: any[]) => {};


### PR DESCRIPTION
## Summary
- restore macOS helper binaries
- add Linux symlinks in `bin/linux`
- let `BIN()` prefer platform-specific paths if present

## Testing
- `bun test`
- `bun "bun serv.ts"`

------
https://chatgpt.com/codex/tasks/task_e_688442579660832884222d04c9552f26